### PR TITLE
update to actions v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
@@ -45,7 +45,7 @@ jobs:
           subject-path: dist
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.target_arch }}
           path: dist


### PR DESCRIPTION
Currently the actions don't run because v3 is deprecated. Migrating to v4 fixes the issue