### PR TITLE
chore(deps): Migrate to actions/attest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +72,7 @@ jobs:
 
       - name: Generate attestations
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest@v4
         with:
           subject-path: ${{ github.workspace }}/build/bin/aapt2-*
 


### PR DESCRIPTION
> As of version 4, actions/attest-build-provenance is simply a wrapper
> on top of actions/attest.
> Existing applications may continue to use the attest-build-provenance
> action, but new implementations should use actions/attest instead.
> Please see the actions/attest repository for usage information.
https://github.com/actions/attest-build-provenance